### PR TITLE
fix #18 - SVG html support for mediaItem

### DIFF
--- a/functions/gql-functions.php
+++ b/functions/gql-functions.php
@@ -50,10 +50,10 @@
 
                             return trim(substr($svg_file_content, $position));
                         } else {
-                            return '';
+                            return 'File is missing';
                         }
                     } else {
-                        return '';
+                        return wp_get_attachment_image( $source->ID, 'full' );
                     }
                 }
             )

--- a/functions/gql-functions.php
+++ b/functions/gql-functions.php
@@ -32,6 +32,32 @@
     			return get_home_url();
     		}
     	]);
+
+        // Add content field for media item
+        register_graphql_field(
+            'mediaItem',
+            'content',
+            array(
+                'type' => 'String',
+                'resolve' => function( $source, $args ) {
+                    if ( $source->mimeType == 'image/svg+xml' ) {
+                        $media_file = get_attached_file( $source->ID );
+                        if ( $media_file ) {
+                            $svg_file_content = file_get_contents($media_file);
+
+                            $find_string   = '<svg';
+                            $position = strpos($svg_file_content, $find_string);
+
+                            return trim(substr($svg_file_content, $position));
+                        } else {
+                            return '';
+                        }
+                    } else {
+                        return '';
+                    }
+                }
+            )
+        );
     }
     add_action('graphql_init', 'whitelist_settings', 1);
 

--- a/functions/gql-functions.php
+++ b/functions/gql-functions.php
@@ -32,11 +32,19 @@
     			return get_home_url();
     		}
     	]);
+    }
+    add_action('graphql_init', 'whitelist_settings', 1);
 
+
+/*
+ * Give media items a `html` field that outputs the SVG element or an IMG element.
+ * SEE https://github.com/wp-graphql/wp-graphql/issues/1035
+ */
+    function fuxt_add_media_element() {
         // Add content field for media item
         register_graphql_field(
             'mediaItem',
-            'content',
+            'element',
             array(
                 'type' => 'String',
                 'resolve' => function( $source, $args ) {
@@ -59,8 +67,7 @@
             )
         );
     }
-    add_action('graphql_init', 'whitelist_settings', 1);
-
+    add_action( 'graphql_register_types', 'fuxt_add_media_element');
 
 /*
  * Give each content node a field of HTML encoded to play nicely with wp-content Vue component
@@ -261,7 +268,7 @@
         $array = (array)$obj;
         $prefix = chr(0).'*'.chr(0);
         return $array[$prefix.$name];
-    }    
+    }
 
 /*
  * Util function for adjacent page id


### PR DESCRIPTION
Added `content` field to the `mediaItem` Post object. 
For the SVG images, it returns `<svg ... </svg>` and empty string for other cases.
`query MyQuery {
  mediaItems {
    nodes {
      sourceUrl
      content
    }
  }
}
`

`mediaItem` is not a GraphQL interface type, so we can not use  `... on ` structure.